### PR TITLE
update README to reflect CRAN presence

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,7 @@ main R SVN repository at http://svn.r-project.org/R/.
 ## Installation
 
 ```{r eval = FALSE}
-devtools::install_github("metacran/rversions")
+install.packages("rversions")
 ```
 
 ## Usage

--- a/inst/README.md
+++ b/inst/README.md
@@ -15,7 +15,7 @@ main R SVN repository at http://svn.r-project.org/R/.
 
 
 ```r
-devtools::install_github("metacran/rversions")
+install.packages("rversions")
 ```
 
 ## Usage


### PR DESCRIPTION
rversions is now on CRAN; this rewrites the README to recommend the CRAN download.
