### PR TITLE
Cache versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,4 @@ Imports:
 Encoding: UTF-8
 RoxygenNote: 5.0.1.9000
 Roxygen: list(markdown = TRUE)
+Suggests: testthat

--- a/R/rversions.R
+++ b/R/rversions.R
@@ -18,38 +18,10 @@
 #' r_versions()
 
 r_versions <- function(dots = TRUE) {
-  
-  # issue http request to svn
-  h <- handle_setheaders(new_handle(customrequest = "PROPFIND"), Depth="1")
-  req <- curl_fetch_memory(r_svn_url, handle = h)
-  
-  # extract xml nodes
-  doc <- read_xml(rawToChar(req$content))
-  prop <- xml_find_all(doc, ".//D:propstat/D:prop", xml_ns(doc))
-  
-  # extract dates and tages
-  dates <- xml_text(xml_find_first(prop, ".//D:creationdate", xml_ns(doc)))
-  tags <- xml_text(xml_find_first(prop, ".//D:getetag", xml_ns(doc)))
-  tags <- sub("^.*/tags/R-([-0-9]+).*$", "\\1", tags)
-  
-  # filter out working branches
-  is_release <- grepl("^[0-9]+-[0-9]+(-[0-9]+|)$", tags)
-  tags <- tags[is_release]
-  dates <- dates[is_release]
-  
-  # use dots for versions
-  if (dots) tags <- gsub('-', '.', tags)
-  
-  # output structure
-  versions <- data.frame(
-    stringsAsFactors = FALSE,
-    version = tags,
-    date = dates
-  )
-  
-  # sort and return
-  df <- versions[order(package_version(tags)), ]
-  rownames(df) <- NULL
+  df <- r_versions_fetch()
+  if (dots) {
+    df$version <- gsub('-', '.', df$version)
+  }
   df
 }
 
@@ -98,4 +70,39 @@ r_oldrel <- function(dots = TRUE) {
 
   latest <- tail(major_minor, 1)
   tail(versions[ major_minor != latest, ], 1)
+}
+
+cache <- new.env(parent = emptyenv())
+r_versions_fetch <- function() {
+  if (is.null(cache$versions)) {
+    # issue http request to svn
+    h <- handle_setheaders(new_handle(customrequest = "PROPFIND"), Depth="1")
+    req <- curl_fetch_memory(r_svn_url, handle = h)
+
+    # extract xml nodes
+    doc <- read_xml(rawToChar(req$content))
+    prop <- xml_find_all(doc, ".//D:propstat/D:prop", xml_ns(doc))
+
+    # extract dates and tages
+    dates <- xml_text(xml_find_first(prop, ".//D:creationdate", xml_ns(doc)))
+    tags <- xml_text(xml_find_first(prop, ".//D:getetag", xml_ns(doc)))
+    tags <- sub("^.*/tags/R-([-0-9]+).*$", "\\1", tags)
+
+    # filter out working branches
+    is_release <- grepl("^[0-9]+-[0-9]+(-[0-9]+|)$", tags)
+    tags <- tags[is_release]
+    dates <- dates[is_release]
+
+    # output structure
+    versions <- data.frame(
+      stringsAsFactors = FALSE,
+      version = tags,
+      date = dates
+    )
+
+    df <- versions[order(package_version(tags)), ]
+    rownames(df) <- NULL
+    cache$versions <- df
+  }
+  cache$versions
 }

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(rversions)
+
+test_check("rversions")

--- a/tests/testthat/test-rversions.R
+++ b/tests/testthat/test-rversions.R
@@ -1,0 +1,29 @@
+context("rversions")
+
+RE_DASH <- "^[0-9]+-[0-9]+(-[0-9]+)?$"
+RE_DOT <- "^[0-9]+\\.[0-9]+(\\.[0-9]+)?$"
+
+test_that("versions", {
+  d <- r_versions()
+  expect_is(d, "data.frame")
+  expect_equal(names(d), c("version", "date"))
+  expect_is(d$version, "character")
+  expect_is(d$date, "character")
+})
+
+test_that("dots", {
+  expect_match(tail(r_versions(FALSE)$version, 1), RE_DASH)
+  expect_match(tail(r_versions(TRUE)$version, 1), RE_DOT)
+  expect_equal(gsub("-", ".", r_versions(FALSE)$version),
+               r_versions(TRUE)$version)
+})
+
+test_that("r_release respects dots", {
+  expect_match(r_release(TRUE), RE_DOT)
+  expect_match(r_release(FALSE), RE_DASH)
+})
+
+test_that("r_oldrel respects dots", {
+  expect_match(r_oldrel(TRUE), RE_DOT)
+  expect_match(r_oldrel(FALSE), RE_DASH)
+})

--- a/tests/testthat/test-rversions.R
+++ b/tests/testthat/test-rversions.R
@@ -19,11 +19,11 @@ test_that("dots", {
 })
 
 test_that("r_release respects dots", {
-  expect_match(r_release(TRUE), RE_DOT)
-  expect_match(r_release(FALSE), RE_DASH)
+  expect_match(r_release(TRUE)$version, RE_DOT)
+  expect_match(r_release(FALSE)$version, RE_DASH)
 })
 
 test_that("r_oldrel respects dots", {
-  expect_match(r_oldrel(TRUE), RE_DOT)
-  expect_match(r_oldrel(FALSE), RE_DASH)
+  expect_match(r_oldrel(TRUE)$version, RE_DOT)
+  expect_match(r_oldrel(FALSE)$version, RE_DASH)
 })


### PR DESCRIPTION
This adds a small caching later to the package.  The versions are unlikely to change within an R session so this seems reasonable.  As such there is no facility for clearing the cache.

I've copied verbatim the code from the original `r_versions` function into the caching call.  The dots translation happens after the cache extraction because that seemed simplest and I doubt it makes a great deal of difference.

I've added a minimal amount of testing so I could check that this did not break things.