### PR TITLE
Make test work even when there is a new version nickname

### DIFF
--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,5 +1,7 @@
 # rversions (development version)
 
+* Fix test of nicknames caching so that it might work even when there is a new version nickname that's not in the package data yet.
+
 # rversions 1.1.0
 
 * All function outputs now also have a column with version nickname(s).

--- a/tests/testthat/test-rversions.R
+++ b/tests/testthat/test-rversions.R
@@ -31,10 +31,10 @@ test_that("r_oldrel respects dots", {
 test_that("on-demand nickname update", {
   d <- r_versions()
   nicks <- cached_nicks()
-
+  
   ## We add foobar to make sure that mocking is in place
   nicks[length(nicks) - 3] <- "foobar"
-  d$nickname[nrow(d) - 3] <- "foobar"
+  d$nickname[length(nicks) - 3] <- "foobar"
 
   mockery::stub(r_versions, "cached_nicks", head(nicks, -2))
   expect_equal(d, r_versions())

--- a/tests/testthat/test-rversions.R
+++ b/tests/testthat/test-rversions.R
@@ -31,7 +31,7 @@ test_that("r_oldrel respects dots", {
 test_that("on-demand nickname update", {
   d <- r_versions()
   nicks <- cached_nicks()
-  
+
   ## We add foobar to make sure that mocking is in place
   nicks[length(nicks) - 3] <- "foobar"
   d$nickname[length(nicks) - 3] <- "foobar"


### PR DESCRIPTION
the test is currently failing because there's a new version nickname that isn't in the package data yet (I'll add it later, the test should work even before then hence this PR).